### PR TITLE
Unescape html

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -368,9 +368,9 @@ html(lang=i18n.language)
           h2=(i18n.t('how.title'))
           h3=(i18n.t('how.subtitle'))         
           ul.steps
-            li.how-open=(i18n.t('how.open'))
-            li.how-subtitles=(i18n.t('how.select'))
-            li.how-play=(i18n.t('how.play'))
+            li.how-open!=(i18n.t('how.open'))
+            li.how-subtitles!=(i18n.t('how.select'))
+            li.how-play!=(i18n.t('how.play'))
       #get-app(data-version='3.9', data-version-android='2.8', data-version-androidtv='1.3')
         .text
           h2=(i18n.t('get-app.new'))        
@@ -412,7 +412,7 @@ html(lang=i18n.language)
             a.github(href='https://github.com/popcorn-official/', title='Github', target='_blank') Github      
         footer
           hr
-          p=(i18n.t('footer.love'))
+          p!=(i18n.t('footer.love'))
 
         
           


### PR DESCRIPTION
There were html tags in the internationalisation files that were escaped. This PR will make them appear as intended.

**Before**
<img width="1359" alt="screen shot 2016-06-10 at 01 36 30" src="https://cloud.githubusercontent.com/assets/11170603/15950061/e00e5a86-2eab-11e6-8d2b-a3472bf7d80d.png">
<img width="601" alt="screen shot 2016-06-10 at 01 36 39" src="https://cloud.githubusercontent.com/assets/11170603/15950063/e2b2d14a-2eab-11e6-9f04-8ff1004cbbe9.png">

**After**
<img width="1315" alt="screen shot 2016-06-10 at 01 36 52" src="https://cloud.githubusercontent.com/assets/11170603/15950071/e839e18a-2eab-11e6-9e7d-b9189316eaad.png">
<img width="421" alt="screen shot 2016-06-10 at 01 36 58" src="https://cloud.githubusercontent.com/assets/11170603/15950074/eb263a6a-2eab-11e6-92b3-92a572eca47c.png">
